### PR TITLE
[494:robot:] Implement Code Quality Status Badges

### DIFF
--- a/.github/workflows/bump_and_publish_release.yml
+++ b/.github/workflows/bump_and_publish_release.yml
@@ -1,4 +1,4 @@
-name: Bump Version & Publish Release on PyPI
+name: Build
 
 on:
   push:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: Code Coverage Report
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -r requirements.txt -r requirements-dev.txt
+      - name: Generate Coverage Report
+        run: make coverage-xml
+      - name: Upload Report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          verbose: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,8 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,3 @@ Changelog
 <!--next-version-placeholder-->
 
 ## v0.1.0 (2022-08-09)
-

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ clean-pip-cache: ## purge the PIP cache to pull latest packages from PyPI
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
+	rm -f coverage.xml
 	rm -fr htmlcov/
 	rm -fr .pytest_cache/
 
@@ -120,6 +121,10 @@ coverage-term: ## check code coverage with a simple terminal report
 coverage-html: coverage-term ## check code coverage with an HTML report
 	@coverage html
 	@$(BROWSER) htmlcov/index.html
+
+.PHONY: coverage-xml
+coverage-xml: coverage-term ## check code coverage with an XML report
+	@coverage xml
 
 .PHONY: install
 install: clean ## install the package to the active Python's site-packages

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pytest-flask-ligand
 ===================
 
-|pre-commit-status|
+|build-status| |pypi-status| |codecov-status| |pre-commit-status|
 
 Pytest fixtures and helper functions to use for testing flask-ligand microservices.
 
@@ -67,6 +67,17 @@ editors.
 .. _Python Black: https://black.readthedocs.io/en/stable/
 .. _editor integration: https://black.readthedocs.io/en/stable/integrations/editors.html
 
+.. |build-status| raw:: html
+
+        <a href="https://github.com/cowofevil/pytest-flask-ligand/actions/workflows/bump_and_publish_release.yml">
+        <img src="https://github.com/cowofevil/pytest-flask-ligand/actions/workflows/bump_and_publish_release.yml/badge.svg" alt="Build"/>
+        </a>
+.. |pypi-status| image:: https://img.shields.io/pypi/v/pytest-flask-ligand?color=blue&logo=pypi
+   :target: https://pypi.org/project/pytest-flask-ligand/
+   :alt: PyPI
+.. |codecov-status| image:: https://img.shields.io/codecov/c/gh/cowofevil/pytest-flask-ligand?color=teal&logo=codecov
+   :target: https://app.codecov.io/gh/cowofevil/pytest-flask-ligand
+   :alt: Codecov
 .. |pre-commit-status| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit


### PR DESCRIPTION
Added new badges for build status, code coverage and PyPI version. Added a
new make target for generating XML coverage reports along with a new GitHub
Actions workflow for generating codecov reports on push to main. Renamed the
"bump_and_publish_release" workflow to make for a better looking badge.