### PR TITLE
[545] Update to Python 3.11 Final

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11-dev']
+        python-version: ['3.10', '3.11']
 
     steps:
       - name: Git Checkout

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ type-check: ## check Python types using mypy
 format: ## format code using black
 	@black pytest_flask_ligand setup.py tests
 
+.PHONY: run-pre-commit
+run-pre-commit: check-pre-commit ## run pre-commit against all files
+	@pre-commit run --all-files
+
 .PHONY: test
 test: ## run tests quickly with the default Python
 	@pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 skipsdist = true
-envlist = py310, py311, pre-commit
+envlist = py310, py311
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.10: py310, pre-commit
+    3.10: py310
     3.11: py311
 
 [testenv]
@@ -18,10 +18,3 @@ deps =
 commands =
     pip3 install -U pip
     py.test --basetemp={envtmpdir} tests
-
-[pre-commit]
-basepython = python3
-skip_install = true
-
-[testenv:pre-commit]
-commands = pre-commit run --all-files


### PR DESCRIPTION
The official final version of Python 3.11 has been released. Update GitHub/tox to start using the new version. Also, disabled pre-commit for tox now that GitHub Actions workflow runs automatically for pre-commit.