### PR TITLE
[560:robot:] Fix Packaging Issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ packages =
     pytest_flask_ligand
 data_files =
     README.rst = README.rst
+    pytest_flask_ligand/py.typed = pytest_flask_ligand/py.typed
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Missing the 'py.typed' marker which is breaking mypy.