### PR TITLE
:bug: One More Chance for CI

### DIFF
--- a/.github/workflows/bump_and_publish_release.yml
+++ b/.github/workflows/bump_and_publish_release.yml
@@ -35,6 +35,16 @@ jobs:
         run: |
           git reset --hard ${{ github.sha }}
 
+      - name: Action | Semantic Version Release
+        id: release
+        # Adjust tag with desired version if applicable.
+        uses: python-semantic-release/python-semantic-release@v10.5.3
+        with:
+          build: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: "github-actions"
+          git_committer_email: "actions@users.noreply.github.com"
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -44,14 +54,8 @@ jobs:
       - name: Install Hatch
         uses: pypa/hatch@install
 
-      - name: Action | Semantic Version Release
-        id: release
-        # Adjust tag with desired version if applicable.
-        uses: python-semantic-release/python-semantic-release@v10.5.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_committer_name: "github-actions"
-          git_committer_email: "actions@users.noreply.github.com"
+      - name: Build Artifacts
+        run: hatch build
 
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v10.5.3


### PR DESCRIPTION
OKAY! So, the neato cool 'python-semantic-release' GitHub Action does the secure and very annoying thing of having a dedicated Python venv for running. The fix is to disable building with 'python-semantic-release' and instead use Hatch directly to build the artifacts.

Pffft!